### PR TITLE
BT radio reset

### DIFF
--- a/examples/pylywsd03mmc.py
+++ b/examples/pylywsd03mmc.py
@@ -18,4 +18,5 @@ for mac in args.mac:
         print(f"Battery: {data.battery}% ({data.voltage} V)")
         print()
     except (Exception,) as e:
+        print(f"An exception of type {type(e).__name__} occured")
         print(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pylywsdxx"
 description = "A Python3 class to interrogate Xiaomi Mijia LYWSD* sensors."
-version = "1.2.2"
+version = "1.3.1"
 dependencies = [
     "bluepy3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pylywsdxx"
 description = "A Python3 class to interrogate Xiaomi Mijia LYWSD* sensors."
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
     "bluepy3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pylywsdxx"
 description = "A Python3 class to interrogate Xiaomi Mijia LYWSD* sensors."
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
     "bluepy3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pylywsdxx"
 description = "A Python3 class to interrogate Xiaomi Mijia LYWSD* sensors."
-version = "1.3.1"
+version = "1.3.4"
 dependencies = [
     "bluepy3",
 ]

--- a/src/pylywsdxx/__init__.py
+++ b/src/pylywsdxx/__init__.py
@@ -2,9 +2,10 @@
 
 from .client import Lywsd02client
 from .client import Lywsd03client
-from .bt_hardware import *
+from .bt_hardware import ble_reset
 
 __all__ = (
     "Lywsd02client",
     "Lywsd03client",
+    "ble_reset",
 )

--- a/src/pylywsdxx/__init__.py
+++ b/src/pylywsdxx/__init__.py
@@ -2,6 +2,7 @@
 
 from .client import Lywsd02client
 from .client import Lywsd03client
+from .bt_hardware import *
 
 __all__ = (
     "Lywsd02client",

--- a/src/pylywsdxx/bt_hardware.py
+++ b/src/pylywsdxx/bt_hardware.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import os
+import time
+
+
+def ble_reset(delay=5.0):
+    """Reset the bluetooth hardware"""
+    # Have you tried turning it off and on again?
+    os.system("/usr/bin/bluetoothctl power off")
+    time.sleep(delay)
+    os.system("/usr/bin/bluetoothctl power on")
+    # if all else fails...
+    # os.system("/usr/bin/sudo /usr/bin/systemctl restart bluetooth.service")

--- a/src/pylywsdxx/client.py
+++ b/src/pylywsdxx/client.py
@@ -3,7 +3,6 @@
 import collections
 import contextlib
 import logging
-import os
 import struct
 import time
 from datetime import datetime, timedelta
@@ -66,6 +65,11 @@ class Lywsd02client:  # pylint: disable=R0902
         self._context_depth += 1
         try:
             yield self
+        # TODO: except to catch connection errors
+        # kimnaty.kimnaty[1372]: *** While talking to room 1.1 (A4:C1:38:6F:E7:CA) an error occured on 2023-04-15 18:20:35
+        # kimnaty.kimnaty[1372]:      -btle- Timed out while trying to connect to peripheral A4:C1:38:6F:E7:CA, addr type: public, interface None, >
+        except Exception as her:
+            print(f"(pylywsdxx.client) An exception of type {type(her).__name__} occured")
         finally:
             self._context_depth -= 1
             if self._context_depth == 0:

--- a/src/pylywsdxx/client.py
+++ b/src/pylywsdxx/client.py
@@ -3,6 +3,7 @@
 import collections
 import contextlib
 import logging
+import os
 import struct
 import time
 from datetime import datetime, timedelta
@@ -344,3 +345,13 @@ class Lywsd03client(Lywsd02client):
             Nothing
         """
         return
+
+
+def ble_reset(delay=5.0):
+    """Reset the bluetooth hardware"""
+    # Have you tried turning it off and on again?
+    os.system("/usr/bin/bluetoothctl power off")
+    time.sleep(delay)
+    os.system("/usr/bin/bluetoothctl power on")
+    # if all else fails...
+    # os.system("/usr/bin/sudo /usr/bin/systemctl restart bluetooth.service")

--- a/src/pylywsdxx/client.py
+++ b/src/pylywsdxx/client.py
@@ -355,13 +355,3 @@ class Lywsd03client(Lywsd02client):
             Nothing
         """
         return
-
-
-def ble_reset(delay=5.0):
-    """Reset the bluetooth hardware"""
-    # Have you tried turning it off and on again?
-    os.system("/usr/bin/bluetoothctl power off")
-    time.sleep(delay)
-    os.system("/usr/bin/bluetoothctl power on")
-    # if all else fails...
-    # os.system("/usr/bin/sudo /usr/bin/systemctl restart bluetooth.service")

--- a/src/pylywsdxx/client.py
+++ b/src/pylywsdxx/client.py
@@ -22,7 +22,9 @@ UUID_NUM_RECORDS = "EBE0CCB9-7A0A-4B0C-8A1A-6FF2997DA3A6"  # _ 8 bytes          
 UUID_RECORD_IDX = "EBE0CCBA-7A0A-4B0C-8A1A-6FF2997DA3A6"  # _  4 bytes               READ WRITE
 
 
-class SensorData(collections.namedtuple("SensorDataBase", ["temperature", "humidity", "battery", "voltage"])):
+class SensorData(
+    collections.namedtuple("SensorDataBase", ["temperature", "humidity", "battery", "voltage"])
+):
     """Class to store sensor data..
     For LYWSD03MMC devices also battery information is available.
     """
@@ -170,7 +172,9 @@ class Lywsd02client:  # pylint: disable=R0902
             self._subscribe(UUID_DATA, self._process_sensor_data)
 
             if not self._peripheral.waitForNotifications(self._notification_timeout):
-                raise TimeoutError(f"No data from device for {self._notification_timeout} seconds")
+                raise TimeoutError(
+                    f"No data from device for {self._notification_timeout} seconds"
+                )
 
     def _get_history_data(self):
         with self.connect():
@@ -198,7 +202,9 @@ class Lywsd02client:  # pylint: disable=R0902
     def _process_sensor_data(self, data):
         temperature, humidity = struct.unpack_from("hB", data)
         temperature /= 100
-        self._data = SensorData(temperature=temperature, humidity=humidity, battery=None, voltage=None)
+        self._data = SensorData(
+            temperature=temperature, humidity=humidity, battery=None, voltage=None
+        )
 
     def _process_history_data(self, data):
         (idx, ts, max_temp, max_hum, min_temp, min_hum) = struct.unpack_from("<IIhBhB", data)
@@ -247,7 +253,9 @@ class Lywsd03client(Lywsd02client):
         Lowest voltage for these batteries is 2.0 V but the BT radio
         on most devices will stop working when below 2.3 V (YMMV).
         """
-        self._data = SensorData(temperature=temperature, humidity=humidity, battery=battery, voltage=voltage)
+        self._data = SensorData(
+            temperature=temperature, humidity=humidity, battery=battery, voltage=voltage
+        )
 
     @property
     def battery(self):
@@ -310,7 +318,9 @@ class Lywsd03client(Lywsd02client):
             datetime: the start time of the device
         """
         if not self._start_time:
-            start_time_delta = self.time[0] - datetime(1970, 1, 1) - timedelta(hours=self.tz_offset)
+            start_time_delta = (
+                self.time[0] - datetime(1970, 1, 1) - timedelta(hours=self.tz_offset)
+            )
             self._start_time = datetime.now() - start_time_delta
         return self._start_time
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # This file is used to override pycodestyle settings
 [pycodestyle]
-max-line-length=120
+max-line-length=96
 ignore=E402,W503
 
 [pydocstyle]
@@ -21,10 +21,10 @@ builtins = _
 convention = google
 
 [pylama:pycodestyle]
-max_line_length = 120
+max_line_length = 96
 ignore=E203,E402,W503
 
 [pylama:pylint]
-max_line_length = 120
+max_line_length = 96
 rcfile = .pylintrc
 disable = C0103,C0114,C0116,E0401,E1136,R0913,R0914,R0915,W0105,W0703,W1203


### PR DESCRIPTION
* some changes due to `black` reformatting as a result of max. linelength reduction.
* added capability to reset (power off/on) BT radio.
* catch and report errors generated by `yield self` for debugging purposes.

Should help in finding a fix for #1.